### PR TITLE
Fix errors for issue-types-1-2

### DIFF
--- a/mistakes.html
+++ b/mistakes.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -33,6 +33,7 @@
       <img
         class="object-cover w-1/2 rounded-full"
         src="https://upload.wikimedia.org/wikipedia/commons/5/56/Chocolate_cupcakes.jpg"
+        alt="Several chocolate frosted cupcakes with rainbow sprinkles. One cupcake has a big bite in it."
       />
     </header>
 
@@ -169,6 +170,7 @@
             <img
               class="rounded-t-3xl h-40 w-full object-contain bg-black"
               src="https://tscpl.org/wp-content/uploads/2015/04/cookiehero.png.png"
+              alt="Side by side images of an attempt at making Sesame Street's Cookie Monster-themed cupcakes. On the left, a neatly frosted blue cookie monster cupcake has a cookie in his mouth and two white gooly eyes. On the right, melted blue icing drips over the side of a sunken cupcake, with googly eyes sadly staring at the camera."
             />
             <div class="p-4 flex flex-col gap-2">
               <h3 class="text-2xl">Help, I'm melting!</h3>
@@ -184,6 +186,7 @@
             <img
               class="rounded-t-3xl h-40 w-full object-contain bg-black"
               src="https://www.wayofcats.com/blog/wp-content/uploads/2009/10/ifixedit.jpg"
+              alt="Staring in concentration, a cat paws at a tray of unbaked chocolate chip cookies. Two speech bubbles appear from the cat's mouth. The first reads, 'This one was missing the kitteh hair, but I have fixed it for you.' The second reads, 'You may bake them now...'"
             />
             <div class="p-4 flex flex-col gap-2">
               <h3 class="text-2xl">This can't be hygenic</h3>
@@ -199,6 +202,7 @@
             <img
               class="rounded-t-3xl h-40 w-full object-contain bg-black"
               src="https://lvphotoblog.com/wp-content/uploads/2021/01/baking-fail.jpg"
+              alt="Side by side images of an attempt to make sweet pull-apart buns in the shape of a ring of decorated teddy bears. On the left, two hands present a plate of neatly decorated teddies in a ring, each with neatly frosted faces and paws. On the right, a many bulbous nodes of dough have baked to form a cobblestone-like ring around a metal cone. A few of the bulbs have roughly drawn faces, and most of the look like they are in states of disinterest or shock."
             />
             <div class="p-4 flex flex-col gap-2">
               <h3 class="text-2xl">Oh, bother.</h3>


### PR DESCRIPTION
Issue type 1: Missing document language

I found this error by opening mistakes.html file in repo, then looking at the top of the page where it has the <html> tag to see if it has lang attribute that matches the language of the page. I noticed that it doesn’t have the lang attribute and after referencing [WCAG SC3.1.1](https://www.w3.org/WAI/WCAG21/Understanding/language-of-page) ,  I updated it to <html lang=“en”> . 
 
Issue type 2: Images without alt text 

After reviewing resource [WCAG SC1.1.1](https://www.w3.org/WAI/WCAG21/Understanding/non-text-content), I looked at each <img> sections of mistakes.html file and I saw that these images are missing alternative text to describe the image. I then looked at index.html files for the corresponding lines and see what texts I would put there. I updated all the <img> sections with corresponding text descriptions from the index.html file.